### PR TITLE
replace all uses of require() in lib/ with import

### DIFF
--- a/lib/Audio/Audio.js
+++ b/lib/Audio/Audio.js
@@ -1,7 +1,11 @@
+import notes500 from "../../data/audio/audio_500.json" assert { type: "json" };
+import notes1000 from "../../data/audio/audio_1000.json" assert { type: "json" };
+import notes2000 from "../../data/audio/audio_2000.json" assert { type: "json" };
+
 const Piano = {
-	500:  { duration: 500,  notes: require("../../data/audio/audio_500.json") },
-	1000: { duration: 1000, notes: require("../../data/audio/audio_1000.json") },
-	2000: { duration: 2000, notes: require("../../data/audio/audio_2000.json") }
+	500:  { duration: 500,  notes: notes500 },
+	1000: { duration: 1000, notes: notes1000 },
+	2000: { duration: 2000, notes: notes2000 },
 }
 
 export { Piano }

--- a/lib/Audio/Audio_1000.js
+++ b/lib/Audio/Audio_1000.js
@@ -1,3 +1,5 @@
-const Piano_1000 = { duration: 1000, notes: require("../../data/audio/audio_1000.json") };
+import notes1000 from "../../data/audio/audio_1000.json" assert { type: "json" };
+
+const Piano_1000 = { duration: 1000, notes: notes1000 };
 
 export { Piano_1000 }

--- a/lib/Audio/Audio_2000.js
+++ b/lib/Audio/Audio_2000.js
@@ -1,3 +1,5 @@
-const Piano_2000 = { duration: 2000, notes: require("../../data/audio/audio_2000.json") };
+import notes2000 from "../../data/audio/audio_2000.json" assert { type: "json" };
+
+const Piano_2000 = { duration: 2000, notes: notes2000 };
 
 export { Piano_2000 }

--- a/lib/Audio/Audio_500.js
+++ b/lib/Audio/Audio_500.js
@@ -1,3 +1,5 @@
-const Piano_500 = { duration: 500, notes: require("../../data/audio/audio_500.json") }
+import notes500 from "../../data/audio/audio_500.json" assert { type: "json" };
+
+const Piano_500 = { duration: 500, notes: notes500 };
 
 export { Piano_500 }

--- a/lib/Notes.js
+++ b/lib/Notes.js
@@ -1,4 +1,4 @@
-const notes = require("../data/notes.json");
+import notes from "../data/notes.json" assert { type: "json" };
 
 const Note = function(note) {
 	const that = this;


### PR DESCRIPTION
# Motivation

I'm building a web app that pulls in `piano-notes`, and my app fails to load with the error `Uncaught ReferenceError: require is not defined` in the browser console. I don't have Node or RequireJS anywhere in my system, so it's not surprising that I'm seeing this error. I've checked the minified output from my build tool (Vite 3.0.4) and the only uses of `require` are from `piano-notes`.

# Changes in this PR
Replace all uses of `require` in the `lib` folder with `import` (this relies on [this ES6 proposal](https://github.com/tc39/proposal-json-modules), which is in Stage 3 but works in the version of Firefox that I tried).

# How is this PR tested
After making these changes, I can successfully build and run my web app locally using `npm link` against my local modified branch. I was not able to run `npm run tests` because of a segfault in `bundle-module`.

# Notes on my setup
I followed the installation instructions (`npm install wilson428/Piano-Notes`) and usage instructions:
```
import { Notes, Piano_500 } from 'piano-notes';

export let notes = new Notes();
notes.loadAudio([Piano_500]);
```